### PR TITLE
Remove `plugin.name`

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,6 @@ const test404plugin = false; // toggle this off for production
 
 module.exports = function netlify404nomore(conf) {
   return {
-    name: 'netlify-plugin-no-more-404',
     /* index html files preDeploy */
     onPostBuild: async ({
       pluginConfig: {


### PR DESCRIPTION
The `name` property of plugins has moved to `manifest.yml` instead.