### PR TITLE
Rename `pluginConfig` to `inputs`

### DIFF
--- a/fixtures/this.test.js
+++ b/fixtures/this.test.js
@@ -10,7 +10,7 @@ test('plugin fixture works', async () => {
   let failMessages = [];
   await initPlugin.onPostBuild({
     // from netlify.yml
-    pluginConfig: {
+    inputs: {
       debugMode: false,
       on404: 'error',
       cacheKey: 'pluginNoMore404Cache2'

--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ module.exports = function netlify404nomore(conf) {
     name: 'netlify-plugin-no-more-404',
     /* index html files preDeploy */
     onPostBuild: async ({
-      pluginConfig: {
+      inputs: {
         debugMode = false, // send true to make it print out more stuff
         on404 = 'error', // either 'warn' or 'error'
         cacheKey = 'pluginNoMore404Cache' // string - helps to quickly switch to a new cache if a mistake was made


### PR DESCRIPTION
The `pluginConfig` argument has been renamed to `inputs`.