### PR TITLE
Add default values and description to inputs

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,9 +14,9 @@ module.exports = function netlify404nomore(conf) {
     /* index html files preDeploy */
     onPostBuild: async ({
       inputs: {
-        debugMode = false, // send true to make it print out more stuff
-        on404 = 'error', // either 'warn' or 'error'
-        cacheKey = 'pluginNoMore404Cache' // string - helps to quickly switch to a new cache if a mistake was made
+        debugMode, // send true to make it print out more stuff
+        on404, // either 'warn' or 'error'
+        cacheKey // string - helps to quickly switch to a new cache if a mistake was made
       },
       constants,
       utils: { build }

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,5 +1,11 @@
 name: netlify-plugin-no-more-404
 inputs:
   - name: debugMode
+    description: (for development) turn true for extra diagnostic logging
+    default: false
   - name: on404
+    description: either "warn" or "error"
+    default: error
   - name: cacheKey
+    description: change this key to a new one any time you need to restart from scratch
+    default: pluginNoMore404Cache


### PR DESCRIPTION
This adds default values and descriptions to `inputs` in `manifest.yml`

Since default values are assigned to inputs, this removes them from the plugin main file.