### PR TITLE
Rename `utils.build.fail()` to `utils.build.failBuild()`

### DIFF
--- a/fixtures/this.test.js
+++ b/fixtures/this.test.js
@@ -23,7 +23,7 @@ test('plugin fixture works', async () => {
     utils: {
       build: {
         // have to mock this too
-        fail(message) {
+        failBuild(message) {
           failMessages.push(message);
         }
       }

--- a/index.js
+++ b/index.js
@@ -97,7 +97,7 @@ module.exports = function netlify404nomore(conf) {
                 'config.on404'
               )} option is set/default to ${chalk.red('error')}`
             );
-            build.fail(`${buildFailMsgs.join(' and ')}, terminating build.`);
+            build.failBuild(`${buildFailMsgs.join(' and ')}, terminating build.`);
           }
         }
       }


### PR DESCRIPTION
`utils.build.fail()` was renamed to `utils.build.failBuild()`. This PR implements this new name.